### PR TITLE
Fix special characters from being escaped twice in links

### DIFF
--- a/src/exporter.js
+++ b/src/exporter.js
@@ -118,9 +118,7 @@ export const entityToHTML = (entity, originalText) => {
         href={entity.data.url}
         target="_blank"
         rel="noopener noreferrer"
-      >
-        {originalText}
-      </a>
+      />
     );
   }
   return originalText;


### PR DESCRIPTION
I opened a pull request to get this merged back into medium-draft, but I doubt that will be in place before launch.